### PR TITLE
Added Pickaxe Ability reminder and rc block

### DIFF
--- a/src/main/java/me/partlysanestudios/partlysaneskies/PartlySaneSkies.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/PartlySaneSkies.java
@@ -39,8 +39,7 @@ import me.partlysanestudios.partlysaneskies.garden.MathematicalHoeRightClicks;
 import me.partlysanestudios.partlysaneskies.garden.SkymartValue;
 import me.partlysanestudios.partlysaneskies.garden.endoffarmnotifer.EndOfFarmNotifier;
 import me.partlysanestudios.partlysaneskies.garden.endoffarmnotifer.RangeHighlight;
-import me.partlysanestudios.partlysaneskies.mining.WormWarning;
-import me.partlysanestudios.partlysaneskies.mining.MiningEvents;
+import me.partlysanestudios.partlysaneskies.mining.*;
 import me.partlysanestudios.partlysaneskies.rngdropbanner.DropBannerDisplay;
 import me.partlysanestudios.partlysaneskies.system.*;
 import me.partlysanestudios.partlysaneskies.system.requests.Request;
@@ -190,6 +189,7 @@ public class PartlySaneSkies {
         MinecraftForge.EVENT_BUS.register(RangeHighlight.INSTANCE);
         MinecraftForge.EVENT_BUS.register(BannerRenderer.INSTANCE);
         MinecraftForge.EVENT_BUS.register(new MiningEvents());
+        MinecraftForge.EVENT_BUS.register(new Pickaxes());
 
 
 

--- a/src/main/java/me/partlysanestudios/partlysaneskies/mining/Pickaxes.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/mining/Pickaxes.java
@@ -1,0 +1,68 @@
+//
+// Written by J10a1n15.
+// See LICENSE for copyright and license notices.
+//
+
+package me.partlysanestudios.partlysaneskies.mining;
+
+import me.partlysanestudios.partlysaneskies.PartlySaneSkies;
+import me.partlysanestudios.partlysaneskies.garden.endoffarmnotifer.EndOfFarmNotifier;
+import me.partlysanestudios.partlysaneskies.system.BannerRenderer;
+import me.partlysanestudios.partlysaneskies.system.PSSBanner;
+import me.partlysanestudios.partlysaneskies.utils.StringUtils;
+import me.partlysanestudios.partlysaneskies.utils.Utils;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Pickaxes {
+    private static final Pattern pattern = Pattern.compile("(Mining Speed Boost|Pickobulus|Maniac Miner|Vein Seeker) is now available!");
+    public static final String[] pickaxeAbilities = {"Mining Speed Boost", "Pickobulus", "Maniac Miner", "Vein Seeker"};
+
+    @SubscribeEvent
+    public void onChat(ClientChatReceivedEvent event) {
+        String message = StringUtils.removeColorCodes(event.message.getFormattedText());
+        Matcher matcher = pattern.matcher(message);
+
+        if (matcher.find()) {
+            if (PartlySaneSkies.config.pickaxeAbilityReadyBanner){
+                BannerRenderer.INSTANCE.renderNewBanner(new PSSBanner("Pickaxe Ability Ready!", (long) (PartlySaneSkies.config.pickaxeBannerTime * 1000), 4.0f, PartlySaneSkies.config.pickaxeBannerColor.toJavaColor()));
+            }
+            if (PartlySaneSkies.config.pickaxeAbilityReadySound) {
+                if (PartlySaneSkies.config.pickaxeAbilityReadySiren) {
+                    PartlySaneSkies.minecraft.thePlayer.playSound("partlysaneskies:airraidsiren", 100, 1);
+                } else {
+                    PartlySaneSkies.minecraft.thePlayer.playSound("partlysaneskies:bell", 100, 1);
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onClick(PlayerInteractEvent event) {
+        if (!PartlySaneSkies.config.blockAbilityOnPrivateIsland) {
+            return;
+        }
+        if (EndOfFarmNotifier.inGarden() || onPrivateIsland()){} else return; //dont mind me not wanting to nest code
+
+        String[] loreOfItemInHand = Utils.getLore(Utils.getCurrentlyHoldingItem()).toArray(new String[0]);
+
+        if (Utils.isArrOfStringsInLore(pickaxeAbilities, loreOfItemInHand)) {
+            event.setCanceled(true);
+        }
+    }
+
+    public static boolean onPrivateIsland() {
+        String location = PartlySaneSkies.getRegionName();
+        location = StringUtils.removeColorCodes(location);
+        location = StringUtils.stripLeading(location);
+        location = StringUtils.stripTrailing(location);
+        location = location.replaceAll("\\P{Print}", ""); // Removes the RANDOM EMOJIS THAT ARE PRESENT IN SKYBLOCK LOCATIONS      - Su rant, pls ignore
+
+        return location.startsWith("Your Island"); //Really hope that's the only private island name, and you cant rename it
+
+    }
+}

--- a/src/main/java/me/partlysanestudios/partlysaneskies/system/OneConfigScreen.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/system/OneConfigScreen.java
@@ -446,7 +446,7 @@ public class OneConfigScreen extends Config {
     public boolean pickaxeAbilityReadySound = false;
 
     @Switch(
-            name = "Use Airraid Siren for Pickaxe Ability Ready",
+            name = "Use Air Raid Siren for Pickaxe Ability Ready",
             subcategory = "Pickaxes",
             description = "Plays a WWII air raid siren when your pickaxe ability is ready. \nPros: \nKeeps you up at late night grinds \n(RECOMMENDED, ESPECIALLY AT 3 AM)",
             category = "Mining"

--- a/src/main/java/me/partlysanestudios/partlysaneskies/system/OneConfigScreen.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/system/OneConfigScreen.java
@@ -427,6 +427,58 @@ public class OneConfigScreen extends Config {
     )
     public boolean wormWarningBannerSound = false;
 
+    //Pickaxes
+
+    @Switch(
+            name = "Pickaxe Ability Ready Banner",
+            subcategory = "Pickaxes",
+            description = "A banner appears on your screen when your pickaxe ability is ready.",
+            category = "Mining"
+    )
+    public boolean pickaxeAbilityReadyBanner = true;
+
+    @Switch(
+            name = "Pickaxe Ability Ready Sound",
+            subcategory = "Pickaxes",
+            description = "Plays a sound when your pickaxe ability is ready.",
+            category = "Mining"
+    )
+    public boolean pickaxeAbilityReadySound = false;
+
+    @Switch(
+            name = "Use Airraid Siren for Pickaxe Ability Ready",
+            subcategory = "Pickaxes",
+            description = "Plays a WWII air raid siren when your pickaxe ability is ready. \nPros: \nKeeps you up at late night grinds \n(RECOMMENDED, ESPECIALLY AT 3 AM)",
+            category = "Mining"
+    )
+    public boolean pickaxeAbilityReadySiren = false;
+
+    @Slider(
+            min = 1,
+            max = 7,
+            subcategory = "Pickaxes",
+            name = "Ready Banner Time",
+            description = "The amount of seconds the ready banner appears for.",
+            category = "Mining"
+    )
+    public float pickaxeBannerTime = 3.5f;
+
+    @Color(
+            subcategory = "Pickaxes",
+            name = "Ready Banner Color",
+            description = "The color of the ready banner text",
+            category = "Mining"
+    )
+    public OneColor pickaxeBannerColor = new OneColor(255, 255, 0);
+
+    @Switch(
+            name = "Block Ability on Private Island (UAYOR)",
+            subcategory = "Pickaxes",
+            description = "Blocks the use of pickaxe abilities on your private island. (Use at your own risk)",
+            category = "Mining"
+    )
+    public boolean blockAbilityOnPrivateIsland = false;
+
     //Events
     @Info(
             type = InfoType.INFO,

--- a/src/main/java/me/partlysanestudios/partlysaneskies/utils/Utils.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/utils/Utils.java
@@ -43,6 +43,21 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class Utils {
+    public static ItemStack getCurrentlyHoldingItem() {
+        return PartlySaneSkies.minecraft.thePlayer.getHeldItem();
+    }
+
+    public static boolean isArrOfStringsInLore(String[] arr, String[] lore) {
+        for (String line : lore) {
+            for (String arrItem : arr) {
+                if (line.contains(arrItem)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     public static HashMap<String, Color> colorCodetoColor = new HashMap<>();
 
     public static void init() {


### PR DESCRIPTION
Pickaxe Abilities get blocked on prv island and garden only

The Ability Reminder supports the banner system, a normal reminder and of course the airraidsiren

The feature in use
https://github.com/PartlySaneStudios/partly-sane-skies/assets/45315647/2917ef67-1cef-4c47-b18b-e601366605ab
Edit: oh my god you can the music, pls ignore

