### PR TITLE
from one to moul

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+libautoupdate = "1.0.3"
+moulconfig = "1.3.0"
+
+[libraries]
+moulconfig = { module = "org.notenoughupdates.moulconfig:MoulConfig", version.ref = "moulconfig" }
+libautoupdate = { module = "moe.nea:libautoupdate", version.ref = "libautoupdate" }

--- a/src/main/java/me/partlysanestudios/partlysaneskies/PartlySaneSkies.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/PartlySaneSkies.java
@@ -19,7 +19,8 @@
 
 package me.partlysanestudios.partlysaneskies;
 
-import cc.polyfrost.oneconfig.config.core.OneColor;
+import me.partlysanestudios.partlysaneskies.config.ConfigManager;
+import me.partlysanestudios.partlysaneskies.temp.OneColor;
 import gg.essential.elementa.ElementaVersion;
 import me.partlysanestudios.partlysaneskies.auctionhouse.menu.AuctionHouseGui;
 import me.partlysanestudios.partlysaneskies.chat.ChatAlertsManager;
@@ -197,6 +198,7 @@ public class PartlySaneSkies {
         MinecraftForge.EVENT_BUS.register(AuctionHouseGui.Companion);
         MinecraftForge.EVENT_BUS.register(new RequiredSecretsFound());
         MinecraftForge.EVENT_BUS.register(new Pickaxes());
+        MinecraftForge.EVENT_BUS.register(new ConfigManager());
         MinecraftForge.EVENT_BUS.register(eofn);
 
 
@@ -285,13 +287,6 @@ public class PartlySaneSkies {
         Utils.log(Level.INFO,"Partly Sane Skies has loaded.");
     }
 
-    public static String getAPIKey() {
-        if (config.forceCustomAPIKey) {
-            return config.apiKey;
-        }
-        return API_KEY;
-    }
-
     // Method runs every tick
     @SubscribeEvent
     public void clientTick(ClientTickEvent evnt) {
@@ -309,17 +304,6 @@ public class PartlySaneSkies {
         eofn.run();
         config.resetBrokenStrings();
         ThemeManager.run();
-    }
-
-    // Runs when the chat message starts with "Your new API key is"
-    // Updates the API key to the new API key
-    @SubscribeEvent
-    public void newApiKey(ClientChatReceivedEvent event) {
-        if (event.message.getUnformattedText().startsWith("Your new API key is ")) {
-            config.apiKey = event.message.getUnformattedText().replace("Your new API key is ", "");
-            Utils.sendClientMessage(("Saved new API key!"));
-            config.save();
-        }
     }
 
     // Runs chat analyzer for debug mode

--- a/src/main/java/me/partlysanestudios/partlysaneskies/config/ConfigManager.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/config/ConfigManager.java
@@ -1,0 +1,4 @@
+package me.partlysanestudios.partlysaneskies.config;
+
+public class ConfigManager {
+}

--- a/src/main/java/me/partlysanestudios/partlysaneskies/system/OneConfigScreen.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/system/OneConfigScreen.java
@@ -6,14 +6,7 @@
 
 package me.partlysanestudios.partlysaneskies.system;
 
-import cc.polyfrost.oneconfig.config.Config;
-import cc.polyfrost.oneconfig.config.annotations.Number;
-import cc.polyfrost.oneconfig.config.annotations.*;
-import cc.polyfrost.oneconfig.config.core.OneColor;
-import cc.polyfrost.oneconfig.config.core.OneKeyBind;
-import cc.polyfrost.oneconfig.config.data.InfoType;
-import cc.polyfrost.oneconfig.config.data.Mod;
-import cc.polyfrost.oneconfig.config.data.ModType;
+import me.partlysanestudios.partlysaneskies.temp.OneColor;
 import org.lwjgl.input.Keyboard;
 
 public class OneConfigScreen extends Config {
@@ -45,25 +38,6 @@ public class OneConfigScreen extends Config {
 
     )
     public static boolean ignored;
-
-    @HypixelKey
-    @Text(
-        secure = true, 
-        name = "API Key", 
-        category = "General", 
-        subcategory = "API", 
-        description = "Do /api new to automatically set your API Key. Do not show your API key to anyone unless you know what you're doing.",
-            size = 2
-    )
-    public String apiKey = "";
-
-    @Switch(
-            name = "Force Custom API Key",
-            category = "General",
-            subcategory = "API",
-            description = "Forces the use of a custom API key for Hypixel requests. (Requires API Key field to be populated)"
-    )
-    public boolean forceCustomAPIKey = false;
 
     @Number(
         min = .1f,

--- a/src/main/java/me/partlysanestudios/partlysaneskies/system/ThemeManager.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/system/ThemeManager.java
@@ -5,10 +5,10 @@
 
 package me.partlysanestudios.partlysaneskies.system;
 
-import cc.polyfrost.oneconfig.config.core.OneColor;
 import gg.essential.elementa.components.UIImage;
 import gg.essential.universal.utils.ReleasedDynamicTexture;
 import me.partlysanestudios.partlysaneskies.PartlySaneSkies;
+import me.partlysanestudios.partlysaneskies.temp.OneColor;
 import me.partlysanestudios.partlysaneskies.utils.ImageUtils;
 import me.partlysanestudios.partlysaneskies.utils.Utils;
 import net.minecraft.client.renderer.texture.TextureUtil;

--- a/src/main/java/me/partlysanestudios/partlysaneskies/system/guicomponents/PSSButton.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/system/guicomponents/PSSButton.java
@@ -5,7 +5,7 @@
 
 package me.partlysanestudios.partlysaneskies.system.guicomponents;
 
-import cc.polyfrost.oneconfig.config.core.OneColor;
+import me.partlysanestudios.partlysaneskies.temp.OneColor;
 import gg.essential.elementa.UIComponent;
 import gg.essential.elementa.components.UIBlock;
 import gg.essential.elementa.components.UIImage;

--- a/src/main/java/me/partlysanestudios/partlysaneskies/temp/OneColor.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/temp/OneColor.java
@@ -1,0 +1,29 @@
+package me.partlysanestudios.partlysaneskies.temp;
+
+import java.awt.Color;
+
+public class OneColor {
+
+    private final Color color;
+
+    public OneColor(Color color) {
+        this.color = color;
+    }
+
+    public OneColor(int i, int i1, int i2, int i3) {
+        // TODO this might not be correct
+        this(new Color(i, i1, i2, i3));
+    }
+
+    public OneColor(int x, int y, int z) {
+        this(new Color(x, y, z));
+    }
+
+    public Color toJavaColor() {
+        return color;
+    }
+
+    public int getRGB() {
+        return color.getRGB();
+    }
+}

--- a/src/main/java/me/partlysanestudios/partlysaneskies/utils/ImageUtils.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/utils/ImageUtils.java
@@ -5,7 +5,8 @@
 
 package me.partlysanestudios.partlysaneskies.utils;
 
-import cc.polyfrost.oneconfig.config.core.OneColor;
+import me.partlysanestudios.partlysaneskies.temp.OneColor;
+import me.partlysanestudios.partlysaneskies.temp.OneColor;
 
 import javax.imageio.ImageIO;
 import java.awt.*;


### PR DESCRIPTION
This PR tries to change the backend from OneConfig to [MoulConfig](https://github.com/NotEnoughUpdates/MoulConfig).
The current state will crash, as I am not fully done porting.

I just removed the API key and created `OneColor` to ditch OneConfig's unnecessarily complicated one color class.