### PR TITLE
Fixed rift locations not working in getRegionName

### DIFF
--- a/src/main/java/me/partlysanestudios/partlysaneskies/PartlySaneSkies.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/PartlySaneSkies.java
@@ -473,8 +473,8 @@ public class PartlySaneSkies {
         String location = null;
 
         for (String line : scoreboard) {
-            if (StringUtils.stripLeading(line).contains("⏣")) {
-                location = StringUtils.stripLeading(line).replace("⏣", "");
+            if (StringUtils.stripLeading(line).contains("⏣") || StringUtils.stripLeading(line).contains("ф")) {
+                location = StringUtils.stripLeading(line).contains("⏣") ? StringUtils.stripLeading(line).replace("⏣", "") : StringUtils.stripLeading(line).replace("ф", "");
                 location = StringUtils.stripLeading(location);
                 break;
             }


### PR DESCRIPTION
Because rift locations have the funny ф in their name instead of ⏣ in their name