### PR TITLE
Add telemetry and privacy features

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ mod.name=Partly Sane Skies
 mod.version=beta-v0.5.1-dogfood
 mod.id=partlysaneskies
 mod.description=Developed by Partly Sane Studios. Discord: https://discord.gg/v4PU3WeH7z
-dogfood=false
+dogfood=true
 

--- a/pages/features/list.md
+++ b/pages/features/list.md
@@ -40,6 +40,10 @@ When switching to a new location region on SkyBlock, an MMO RPG style banner wil
 
 Have you ever wanted to make crêpes, and don't have access to internet, but you do have access to SkyBlock? Well we've got you covered. Simply by doing /crêpes, you too can make crêpes from some random recipe we found on the internet.
 
+### Privacy
+
+This toggle blocks other mods wanting to send data to their servers. Currently supported mods are essentials & dungeon guide. If you know more mods that send that kind of data, feel free to report that in our discord server. This is a privacy feature, and is off by default.
+
 # Chat Features
 
 ### Chat Alerts

--- a/src/main/java/me/partlysanestudios/partlysaneskies/PartlySaneSkies.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/PartlySaneSkies.java
@@ -87,7 +87,7 @@ public class PartlySaneSkies {
     public static final String VERSION = "@MOD_VERSION@";
     //    -----------------------CHANGE TO FALSE BEFORE RELEASING
     public static final boolean DOGFOOD = Boolean.parseBoolean("@DOGFOOD@");
-    public static final String CHAT_PREFIX = ("§r§b§lPartly Sane Skies§r§7>> §r");
+    public static final String CHAT_PREFIX = "§r§b§lPartly Sane Skies§r§7>> §r";
     public static final boolean IS_LEGACY_VERSION = false;
     public static String discordCode = "v4PU3WeH7z";
 

--- a/src/main/java/me/partlysanestudios/partlysaneskies/mixin/privacy/MixinDungeonGuideCollectDiagnostics.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/mixin/privacy/MixinDungeonGuideCollectDiagnostics.java
@@ -5,7 +5,7 @@
  *
  */
 
-package me.partlysanestudios.partlysaneskies.mixin;
+package me.partlysanestudios.partlysaneskies.mixin.privacy;
 
 import me.partlysanestudios.partlysaneskies.PartlySaneSkies;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/java/me/partlysanestudios/partlysaneskies/mixin/privacy/MixinEssentialsTelemetryManager.java
+++ b/src/main/java/me/partlysanestudios/partlysaneskies/mixin/privacy/MixinEssentialsTelemetryManager.java
@@ -1,0 +1,39 @@
+/*
+ *
+ * Written by J10a1n15.
+ * See LICENSE for copyright and license notices.
+ *
+ */
+
+package me.partlysanestudios.partlysaneskies.mixin.privacy;
+
+import me.partlysanestudios.partlysaneskies.PartlySaneSkies;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = "gg.essential.network.connectionmanager.telemetry.TelemetryManager", remap = false)
+public class MixinEssentialsTelemetryManager {
+    @Inject(method = "sendHardwareAndOSTelemetry*", at = @At("HEAD"), cancellable = true)
+    public void onSendHardwareAndOSTelemetryHead(CallbackInfo ci) {
+        if (PartlySaneSkies.config == null) {
+            return;
+        }
+        if (PartlySaneSkies.config.privacyMode) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "enqueue*", at = @At("HEAD"), cancellable = true)
+    public void onEnqueueHead(CallbackInfo ci) {
+        if (PartlySaneSkies.config == null) {
+            return;
+        }
+        if (PartlySaneSkies.config.privacyMode) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/mixins.pss.json
+++ b/src/main/resources/mixins.pss.json
@@ -1,6 +1,7 @@
 {
   "package": "me.partlysanestudios.partlysaneskies.mixin",
   "mixins": [
-    "MixinDungeonGuideCollectDiagnostics"
+    "privacy.MixinDungeonGuideCollectDiagnostics",
+    "privacy.MixinEssentialsTelemetryManager"
   ]
 }


### PR DESCRIPTION
This pull request adds a telemetry block for essentials and a privacy feature to block data sending by other mods. The telemetry block cancels the sending of hardware and OS telemetry if the privacy mode is enabled. The privacy feature blocks other mods, such as essentials and dungeon guide, from sending data to their servers. The privacy feature is off by default.