### PR TITLE
Fix: Crash with Healer Alert

### DIFF
--- a/src/main/kotlin/me/partlysanestudios/partlysaneskies/features/dungeons/HealthAlert.kt
+++ b/src/main/kotlin/me/partlysanestudios/partlysaneskies/features/dungeons/HealthAlert.kt
@@ -22,6 +22,7 @@ import java.awt.Color
 
 
 object HealthAlert {
+
     private var lastWarnTime = 0L
 
     private fun isPlayerLowOnHealth(): Boolean {
@@ -37,8 +38,8 @@ object HealthAlert {
             }
 
             // TODO: do with regex
-            val indexOfFirstSpace = line.indexOf(" ")
-            val indexOfSecondSpace = line.indexOf(" ", indexOfFirstSpace + 1)
+            val indexOfFirstSpace = line.indexOf(" ").takeIf { it >= 0 } ?: return false
+            val indexOfSecondSpace = line.indexOf(" ", indexOfFirstSpace + 1).takeIf { it >= 0 } ?: return false
             val health = line.substring(indexOfSecondSpace)
             if (PartlySaneSkies.config.colouredHealerAlert == 1) {
                 return health.contains("§e") || health.indexOf("§c") != health.lastIndexOf("§c")
@@ -50,7 +51,7 @@ object HealthAlert {
     }
 
     private fun alertWhenPlayerLowOnHealth(): Boolean {
-        if (!config.alertOutsideDungeons && !IslandType.CATACOMBS.onIsland()){
+        if (!config.alertOutsideDungeons && !IslandType.CATACOMBS.onIsland()) {
             return false
         }
 
@@ -77,7 +78,13 @@ object HealthAlert {
                 return
             }
             lastWarnTime = PartlySaneSkies.time
-            BannerRenderer.renderNewBanner(PSSBanner("A player in your party is low", 3500, color = config.partyMemberLowColor.toJavaColor()))
+            BannerRenderer.renderNewBanner(
+                PSSBanner(
+                    "A player in your party is low",
+                    3500,
+                    color = config.partyMemberLowColor.toJavaColor()
+                )
+            )
             PartlySaneSkies.minecraft.soundHandler
                 .playSound(PositionedSoundRecord.create(ResourceLocation("partlysaneskies", "bell")))
         }
@@ -91,7 +98,13 @@ object HealthAlert {
                 return
             }
             lastWarnTime = PartlySaneSkies.time
-            BannerRenderer.renderNewBanner(PSSBanner("Your health is low", 3500, color = config.playerLowColor.toJavaColor()))
+            BannerRenderer.renderNewBanner(
+                PSSBanner(
+                    "Your health is low",
+                    3500,
+                    color = config.playerLowColor.toJavaColor()
+                )
+            )
             PartlySaneSkies.minecraft.soundHandler
                 .playSound(PositionedSoundRecord.create(ResourceLocation("partlysaneskies", "bell")))
         }


### PR DESCRIPTION
**Untested**

java.lang.StringIndexOutOfBoundsException: String index out of range: -1
at java.lang.String.substring(Unknown Source)
at me.partlysanestudios.partlysaneskies.features.dungeons.HealthAlert.isPlayerLowOnHealth(HealthAlert.kt:42)
at me.partlysanestudios.partlysaneskies.features.dungeons.HealthAlert.checkPlayerTick(HealthAlert.kt:71)