### PR TITLE
Merge Conflicts Label

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -15,7 +15,7 @@ jobs:
     main:
         runs-on: ubuntu-latest
         steps:
-            - name: check if prs are dirty
+            - name: Update PRs with merge conflicts label
               uses: eps1lon/actions-label-merge-conflict@v3
               with:
                   dirtyLabel: "Merge Conflicts"

--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,25 @@
+# https://github.com/marketplace/actions/label-conflicting-pull-requests
+
+name: "Merge Conflicts Label"
+on:
+    # So that PRs touching the same files as the push are updated
+    push:
+        branches: [ main ]
+    # So that the `dirtyLabel` is removed if conflicts are resolve
+    # We recommend `pull_request_target` so that GitHub secrets are available.
+    # In `pull_request` we wouldn't be able to change labels of fork PRs
+    pull_request_target:
+        types: [ opened, synchronize ]
+
+jobs:
+    main:
+        runs-on: ubuntu-latest
+        steps:
+            - name: check if prs are dirty
+              uses: eps1lon/actions-label-merge-conflict@v3
+              with:
+                  dirtyLabel: "Merge Conflicts"
+                  #removeOnDirtyLabel: "PR: ready to ship"
+                  repoToken: "${{ secrets.GITHUB_TOKEN }}"
+                  commentOnDirty: "This pull request has conflicts, please resolve those before the pull request can be reviewed."
+                  commentOnClean: "Conflicts have been resolved!"


### PR DESCRIPTION
Adds a label on PRs that have merge conflicts, and also comments on those PRs when merge conflicts happen/get solved.

Taken from: [Label Conflicting Pull Requests](https://github.com/marketplace/actions/label-conflicting-pull-requests)