### PR TITLE
Relocate DiscordIPC

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,12 @@ toolkitGitHubPublishing {
     repository.set("partly-sane-skies")
 }
 
+tasks {
+    fatJar {
+        relocate("com.jagrosh.discordipc", "me.partlysanestudios.partlysaneskies.deps.discordipc")
+    }
+}
+
 bloom {
     val dogfood: String by project
     val releaseChannel: String by project


### PR DESCRIPTION
Sets DiscordIPC to be relocated as to not cause conflicts with other mods that forgot to relocate it.